### PR TITLE
fix: create proper redirect for non-locale paths

### DIFF
--- a/.changeset/violet-otters-destroy.md
+++ b/.changeset/violet-otters-destroy.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/next-intl-custom-paths": minor
+---
+
+Fix double redirect bug when path has no locale

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -18,6 +18,7 @@ describe("rewrite request for ", () => {
 
 			const result = processRequest(request, {
 				defaultLocale: "en-US",
+				localePrefix: "as-needed",
 				localePrefixForRoot: "as-needed",
 				pathToLocaleMapping: {
 					en: "en-US",
@@ -33,6 +34,7 @@ describe("rewrite request for ", () => {
 
 	it.each([
 		["http://example.org/", "/en"],
+		["http://example.org/foobar", "/en/foobar"],
 		["http://example.org/en-US", "/en"],
 		["http://example.org/en-US/", "/en"],
 		["http://example.org/en-US/foobar", "/en/foobar"],
@@ -43,6 +45,7 @@ describe("rewrite request for ", () => {
 
 			const result = processRequest(request, {
 				defaultLocale: "en-US",
+				localePrefix: "always",
 				localePrefixForRoot: "always",
 				pathToLocaleMapping: {
 					en: "en-US",


### PR DESCRIPTION
When the path didn’t have a locale but the `localePrefix` was set to `always` we let next-intl redirect the user to `/${defaultLocale}/${path}`. On visit we then rewrote that to `/${defaultPathLocale}/${path}` and redirect the client again.

This makes sure we do the redirect ourselves skipping an extra redirect
