### PR TITLE
fix(navigation): remove locale from path for "as-needed" usecase

### DIFF
--- a/.changeset/cool-gorillas-exercise.md
+++ b/.changeset/cool-gorillas-exercise.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/next-intl-custom-paths": minor
+---
+
+Fix Link component with as-needed localePrefix

--- a/examples/next-intl/src/app/[locale]/page.tsx
+++ b/examples/next-intl/src/app/[locale]/page.tsx
@@ -1,4 +1,5 @@
 import PageLayout from "components/PageLayout";
+import { Link } from "navigation";
 import { useTranslations } from "next-intl";
 import { unstable_setRequestLocale } from "next-intl/server";
 
@@ -15,6 +16,9 @@ export default function IndexPage({ params: { locale } }: Props) {
 	return (
 		<PageLayout title={t("title")}>
 			<p>Hello!</p>
+			<Link className="inline-block bg-white p-4 rounded-md" href="/pathnames">
+				Pathnames link
+			</Link>
 			<p className="max-w-[590px]">
 				{t.rich("description", {
 					code: (chunks) => (

--- a/src/navigation.tsx
+++ b/src/navigation.tsx
@@ -83,12 +83,9 @@ export function createLocalizedNavigation<
 
 		// If the `localePrefixForRoot` is set to "as-needed" then we don't want to
 		// include the locale path in the URL for the root page. So erase it
-		if (
-			localePrefixForRoot === "as-needed" &&
-			wantLocale === defaultLocale &&
-			href === "/"
-		) {
-			localePath = undefined;
+		// Also has the side usecase of not having the localePrefix on "always".
+		if (localePrefixForRoot === "as-needed" && wantLocale === defaultLocale) {
+			if (href === "/" || localePrefix !== "always") localePath = undefined;
 		}
 
 		return (


### PR DESCRIPTION
When localePrefix is set to "as-needed" we shouldn't add the locale to the Link component.
